### PR TITLE
Fix error on host undefined

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -9,12 +9,14 @@ function plugin(fastify, options, next) {
       const {
         headers: { host },
         url
-      } = req;
-      const redirectUrl = `https://${host.split(":")[0]}${url}`;
-      res.writeHead(301, {
-        Location: redirectUrl
-      });
-      res.end();
+      } = req;      
+      if (host) {
+        const redirectUrl = `https://${host.split(":")[0]}${url}`;
+        res.writeHead(301, {
+          Location: redirectUrl
+        });
+        res.end();
+      }
     })
     .listen(httpPort);
 


### PR DESCRIPTION
.../node_modules/fastify-https-redirect/plugin.js:13
      const redirectUrl = `https://${host.split(":")[0]}${url}`;
                                          ^
TypeError: Cannot read property 'split' of undefined
    at Server.<anonymous> (/root/myapp/node_modules/fastify-https-redirect/plugin.js:13:43)
    at Server.emit (events.js:198:13)
    at parserOnIncoming (_http_server.js:679:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)